### PR TITLE
Added message type and passed message content instead of message object

### DIFF
--- a/model.py
+++ b/model.py
@@ -76,13 +76,13 @@ async def start():
     cl.user_session.set("chain", chain)
 
 @cl.on_message
-async def main(message):
+async def main(message: cl.Message):
     chain = cl.user_session.get("chain") 
     cb = cl.AsyncLangchainCallbackHandler(
         stream_final_answer=True, answer_prefix_tokens=["FINAL", "ANSWER"]
     )
     cb.answer_reached = True
-    res = await chain.acall(message, callbacks=[cb])
+    res = await chain.acall(message.content, callbacks=[cb])
     answer = res["result"]
     sources = res["source_documents"]
 


### PR DESCRIPTION
The existing code was failing with below error:
```Message object has no attribute replace```
As per below document, it should be passed Message's content instead of Message object: https://docs.chainlit.io/api-reference/integrations/langchain#asynchronous-callback-handler