### PR TITLE
Fix import statement for PromptTemplate in model.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,5 +1,5 @@
 from langchain.document_loaders import PyPDFLoader, DirectoryLoader
-from langchain import PromptTemplate
+from langchain.prompts import PromptTemplate
 from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.vectorstores import FAISS
 from langchain.llms import CTransformers


### PR DESCRIPTION
Changes Made
- Updated import statement for `PromptTemplate` in `model.py`.

Context
I encountered a warning related to the import statement for `PromptTemplate` in the `model.py` file. The warning suggested updating the import to `langchain.prompts.PromptTemplate` instead of `langchain.PromptTemplate`. This pull request addresses that warning by making the necessary changes.

Additional Information
- This change improves code quality and ensures compatibility with the latest practices.
- The code has been tested locally and runs without errors.

Thank You!


