### PR TITLE
Import libraries changes

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -1,6 +1,6 @@
-from langchain.embeddings import HuggingFaceEmbeddings
-from langchain.vectorstores import FAISS
-from langchain.document_loaders import PyPDFLoader, DirectoryLoader
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import FAISS
+from langchain_community.document_loaders import PyPDFLoader, DirectoryLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter 
 
 DATA_PATH = 'data/'

--- a/model.py
+++ b/model.py
@@ -1,8 +1,8 @@
-from langchain.document_loaders import PyPDFLoader, DirectoryLoader
+from langchain_community.document_loaders import PyPDFLoader, DirectoryLoader
 from langchain.prompts import PromptTemplate
-from langchain.embeddings import HuggingFaceEmbeddings
-from langchain.vectorstores import FAISS
-from langchain.llms import CTransformers
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import FAISS
+from langchain_community.llms import CTransformers
 from langchain.chains import RetrievalQA
 import chainlit as cl
 


### PR DESCRIPTION
**Use "langchain_community" instead of only "langchain" while importing some libraries as it has been deprecated. See latest langchain documents.**

**Error:**
e:\data science work\llama-chatbot-medical\ned-llama2-chatbot\ned_chabot_huggingface_repo\ned-chatbot\venv\lib\site-packages\langchain\document_loaders\__init__.py:36: LangChainDeprecationWarning: Importing document loaders from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.document_loaders import PyPDFLoader`.

To install langchain-community run `pip install -U langchain-community`.
  warnings.warn(
e:\data science work\llama-chatbot-medical\ned-llama2-chatbot\ned_chabot_huggingface_repo\ned-chatbot\venv\lib\site-packages\langchain\document_loaders\__init__.py:36: LangChainDeprecationWarning: Importing document loaders from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.document_loaders import DirectoryLoader`.

To install langchain-community run `pip install -U langchain-community`.
  warnings.warn(
e:\data science work\llama-chatbot-medical\ned-llama2-chatbot\ned_chabot_huggingface_repo\ned-chatbot\venv\lib\site-packages\langchain\embeddings\__init__.py:29: LangChainDeprengChainDeprecationWarning: Importing embeddings from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.embeddings import HuggingFaceEmbeddings`.